### PR TITLE
태그 이슈 문제 해결

### DIFF
--- a/front/app/blog/edit/[id]/page.tsx
+++ b/front/app/blog/edit/[id]/page.tsx
@@ -31,7 +31,7 @@ export default function EditContent(props) {
   const [body, setBody] = useState('')
   const [selectedTags, setSelectedTags] = useState<string[]>([])
   const { accessToken } = useContext(AuthContext)
-  const { tags, fetchTags } = useContext(TagContext)
+  const { tags, fetchContentTag, fetchRegisterTag } = useContext(TagContext)
 
   useEffect(() => {
     const contentData = async (id: number) => {
@@ -78,6 +78,8 @@ export default function EditContent(props) {
     if (contentResponse.ok) {
       alert('게시글 수정 성공!')
       // fetchTags()
+      // fetchContentTag()
+      // fetchRegisterTag()
       router.push('/blog')
     } else {
       alert('게시글 수정 실패....')

--- a/front/app/blog/post/[id]/page.tsx
+++ b/front/app/blog/post/[id]/page.tsx
@@ -19,7 +19,7 @@ export default function NewPost(props) {
   const [body, setBody] = useState('')
   const [selectedTags, setSelectedTags] = useState<string[]>([])
   const { accessToken } = useContext(AuthContext)
-  const { tags, fetchTags } = useContext(TagContext)
+  const { tags, fetchContentTag, fetchRegisterTag } = useContext(TagContext)
 
   const handleComplete = async () => {
     const content = {
@@ -54,7 +54,9 @@ export default function NewPost(props) {
 
     if (contentResponse.ok && tagResponse.ok) {
       alert('게시글 작성 성공!')
-      fetchTags()
+      fetchContentTag()
+      fetchRegisterTag()
+
       router.push('/blog')
     } else if (!contentResponse.ok) {
       alert('게시글 작성 실패....')

--- a/front/components/hooks/useTag.tsx
+++ b/front/components/hooks/useTag.tsx
@@ -3,14 +3,24 @@
 import { createContext, ReactNode, useEffect, useState } from 'react'
 import { ContentTag } from '@/data/ContentTag'
 import process from 'process'
+import { RegisterTag } from '@/data/RegisterTag'
 
 const TagContext = createContext({
-  tags: null as ContentTag[] | null,
-  fetchTags: async () => {},
+  tags: null as RegisterTag[] | null,
+  contentTags: null as ContentTag[] | null,
+  fetchContentTag: async () => {},
+  fetchRegisterTag: async () => {},
 })
 
 interface Props {
   children: ReactNode | ReactNode[]
+}
+
+export async function fetchRegisterTagData(): Promise<{ data: { tags: RegisterTag[] } }> {
+  const data = await fetch(process.env.NEXT_PUBLIC_BACKEND_URL + '/api/v1/tags', {
+    method: 'GET',
+  })
+  return data.json()
 }
 
 export async function fetchTagData(): Promise<{ data: { tags: ContentTag[] } }> {
@@ -21,18 +31,29 @@ export async function fetchTagData(): Promise<{ data: { tags: ContentTag[] } }> 
 }
 
 const TagProvider = ({ children }: Props) => {
-  const [tags, setTags] = useState<ContentTag[]>([])
+  const [contentTags, setContentTags] = useState<ContentTag[]>([])
+  const [tags, setTags] = useState<RegisterTag[]>([])
 
   useEffect(() => {
-    fetchTags()
+    fetchContentTag()
+    fetchRegisterTag()
   }, [])
 
-  const fetchTags = async () => {
+  const fetchContentTag = async () => {
     const response = await fetchTagData()
+    setContentTags(response.data.tags)
+  }
+
+  const fetchRegisterTag = async () => {
+    const response = await fetchRegisterTagData()
     setTags(response.data.tags)
   }
 
-  return <TagContext.Provider value={{ tags, fetchTags }}>{children}</TagContext.Provider>
+  return (
+    <TagContext.Provider value={{ tags, contentTags, fetchContentTag, fetchRegisterTag }}>
+      {children}
+    </TagContext.Provider>
+  )
 }
 
 export { TagProvider, TagContext }

--- a/front/data/RegisterTag.tsx
+++ b/front/data/RegisterTag.tsx
@@ -1,0 +1,3 @@
+export interface RegisterTag {
+  tagName: string
+}

--- a/front/layouts/ListLayoutWithTags.tsx
+++ b/front/layouts/ListLayoutWithTags.tsx
@@ -77,7 +77,7 @@ export default function ListLayoutWithTags({ title }: ListLayoutProps) {
   const pageNumber = params !== null ? parseInt(params) : 1
   const [contents, setContents] = useState<ContentItem[]>([])
   const [pagination, setPagination] = useState<PaginationProps | null>(null)
-  const { tags } = useContext(TagContext)
+  const { contentTags } = useContext(TagContext)
 
   useEffect(() => {
     const fetchContents = async () => {
@@ -105,7 +105,7 @@ export default function ListLayoutWithTags({ title }: ListLayoutProps) {
             <div className="px-6 py-4">
               <h3 className="font-bold uppercase text-primary-500">Category</h3>
               <ul>
-                {tags?.map((t) => {
+                {contentTags?.map((t) => {
                   return (
                     <li key={t.tagName} className="my-3">
                       <Link


### PR DESCRIPTION
#1 

- 변경 이유
블로그 글 작성 페이지에서 태그를 선택할 때 전체 태그가 발생하지 않는 문제 발생
원인은, 프론트의 Tag콘텍스트에서 호출하는 api가 전체 태그를 조회하는 것이 아닌, 게시글에 등록된 전체 태그를 가져오는 것으로 설정되어 있었음.

<img width="1074" alt="스크린샷 2024-05-20 오후 6 17 05" src="https://github.com/dnjsals45/ministory/assets/44596433/816fd527-51b1-4843-a877-9caecbf891d7">

-  변경 사항
등록된 태그 이외에도 전체 태그를 가져오는 부분을 추가함
이로써, 블로그를 조회할 때에는 등록된 태그를 사용하고, 게시글을 작성할 때에는 전체 태그를 가져오게 하였음