### PR TITLE
jjwt 버전 변경 및 tag 페이지 변수명 변경

### DIFF
--- a/back/ministory/build.gradle
+++ b/back/ministory/build.gradle
@@ -41,9 +41,9 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
     // jwt
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
     // Jsoup (Html 파싱)
     implementation 'org.jsoup:jsoup:1.17.2'

--- a/front/layouts/TagListLayout.tsx
+++ b/front/layouts/TagListLayout.tsx
@@ -79,7 +79,7 @@ export default function ListLayoutWithTags({ title, tagName }: ListLayoutProps) 
   const pageNumber = params !== null ? parseInt(params) : 1
   const [contents, setContents] = useState<ContentItem[]>([])
   const [pagination, setPagination] = useState<PaginationProps | null>(null)
-  const { tags } = useContext(TagContext)
+  const { contentTags } = useContext(TagContext)
 
   useEffect(() => {
     const fetchContents = async () => {
@@ -107,7 +107,7 @@ export default function ListLayoutWithTags({ title, tagName }: ListLayoutProps) 
             <div className="px-6 py-4">
               <h3 className="font-bold uppercase text-primary-500">Category</h3>
               <ul>
-                {tags?.map((t) => {
+                {contentTags?.map((t) => {
                   return (
                     <li key={t.tagName} className="my-3">
                       <Link


### PR DESCRIPTION
- 변경 사항
백엔드: jjwt 라이브러리 버전 변경 (12.0.3 -> 12.0.5)
프론트엔드: Tag 페이지 Tag컨텍스트 사용 변수명 변경(tags -> contentTags) // 빌드 시 에러 발생