### PR TITLE
백엔드 자동로그인 기능을 위한 RT 및 Redis 도입 / 프론트엔드 customFetch 로의 변경

### DIFF
--- a/back/ministory/build.gradle
+++ b/back/ministory/build.gradle
@@ -59,6 +59,9 @@ dependencies {
 
     // AWS S3
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.0'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/back/ministory/src/main/java/seongmin/ministory/api/content/controller/ContentController.java
+++ b/back/ministory/src/main/java/seongmin/ministory/api/content/controller/ContentController.java
@@ -53,14 +53,14 @@ public class ContentController {
 
     @Operation(summary = "게시글 1개 생성", description = "기본적인 내용만 있는 게시글 생성")
     @PostMapping("")
-    @PreAuthorize("isAuthenticated() && #userDetails.getRole() == 'ROLE_ADMIN'")
+    @PreAuthorize("isAuthenticated() && hasRole('ROLE_ADMIN')")
     public ResponseEntity<?> createContent(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok().body(SuccessResponse.from(contentService.createContent(userDetails)));
     }
 
     @Operation(summary = "게시글 1개 수정", description = "complete가 true면 완성, 아니면 임시저장")
     @PatchMapping("/{content_id}")
-    @PreAuthorize("isAuthenticated() && #userDetails.getRole() == 'ROLE_ADMIN'")
+    @PreAuthorize("isAuthenticated() && hasRole('ROLE_ADMIN')")
     public ResponseEntity<?> modifyContent(@Parameter(name = "content_id", description = "게시글 번호")
                                            @PathVariable(name = "content_id") Long contentId,
                                            @Valid @RequestBody ModifyContentReq req,

--- a/back/ministory/src/main/java/seongmin/ministory/api/tag/controller/TagController.java
+++ b/back/ministory/src/main/java/seongmin/ministory/api/tag/controller/TagController.java
@@ -28,7 +28,7 @@ public class TagController {
 
     @Operation(summary = "태그 등록", description = "사용할 태그 등록(Admin만)")
     @PostMapping("/register")
-    @PreAuthorize("isAuthenticated() && #userDetails.getRole() == 'ROLE_ADMIN'")
+    @PreAuthorize("isAuthenticated() && hasRole('ROLE_ADMIN')")
     public ResponseEntity<?> registerTag(@RequestBody RegisterTagReq req,
                                          @AuthenticationPrincipal CustomUserDetails userDetails) {
         tagService.registerTag(req);

--- a/back/ministory/src/main/java/seongmin/ministory/api/user/controller/UserController.java
+++ b/back/ministory/src/main/java/seongmin/ministory/api/user/controller/UserController.java
@@ -14,6 +14,8 @@ import seongmin.ministory.api.user.service.UserService;
 import seongmin.ministory.api.user.service.UserUtilService;
 import seongmin.ministory.common.auth.dto.CustomUserDetails;
 import seongmin.ministory.common.jwt.dto.JwtTokenInfo;
+import seongmin.ministory.common.jwt.provider.AccessTokenProvider;
+import seongmin.ministory.common.jwt.provider.RefreshTokenProvider;
 import seongmin.ministory.common.jwt.provider.TokenProvider;
 import seongmin.ministory.common.response.SuccessResponse;
 import seongmin.ministory.common.response.code.AuthErrorCode;
@@ -29,6 +31,7 @@ import java.io.IOException;
 @RequestMapping("/api/v1/users")
 public class UserController {
     private final TokenProvider accessTokenProvider;
+    private final TokenProvider refreshTokenProvider;
     private final UserService userService;
     private final UserUtilService userUtilService;
 
@@ -75,7 +78,9 @@ public class UserController {
             default -> throw new AuthErrorException(AuthErrorCode.UNKNOWN_PROVIDER, "존재하지 않는 프로바이더 입니다.");
         }
         String accessToken = accessTokenProvider.generateToken(tokenInfo);
-        log.info("AT: {}", accessToken);
+        String refreshToken = refreshTokenProvider.generateToken(tokenInfo);
+
+        log.info("RT: {}", refreshToken);
 
 
         return ResponseEntity.ok().header("Access-Token", accessToken).body(SuccessResponse.noContent());

--- a/back/ministory/src/main/java/seongmin/ministory/api/user/controller/UserController.java
+++ b/back/ministory/src/main/java/seongmin/ministory/api/user/controller/UserController.java
@@ -82,7 +82,6 @@ public class UserController {
         String refreshToken = refreshTokenProvider.generateToken(tokenInfo);
 
         ResponseCookie refreshTokenCookie = ResponseCookie.from("Refresh-Token", refreshToken)
-                .domain("localhost")
                 .httpOnly(true)
                 .path("/")
                 .maxAge(60 * 60 * 24)
@@ -107,7 +106,6 @@ public class UserController {
     public ResponseEntity<?> logOut(HttpServletResponse response) {
 
         ResponseCookie refreshTokenCookie = ResponseCookie.from("Refresh-Token", "")
-                .domain("localhost")
                 .httpOnly(true)
                 .path("/")
                 .maxAge(0)

--- a/back/ministory/src/main/java/seongmin/ministory/api/user/controller/UserController.java
+++ b/back/ministory/src/main/java/seongmin/ministory/api/user/controller/UserController.java
@@ -47,7 +47,7 @@ public class UserController {
         String accessToken = userUtilService.login(user);
 
         return ResponseEntity.noContent()
-                .header("Authorization", "Bearer " + accessToken)
+                .header("Acess-Token", accessToken)
                 .build();
     }
 
@@ -85,7 +85,7 @@ public class UserController {
 
         ResponseCookie refreshTokenCookie = ResponseCookie.from("Refresh-Token", refreshToken)
                 .httpOnly(true)
-                .path("/")
+                .path("http://localhost:3000")
                 .maxAge(60 * 60 * 24 * 30)
                 .secure(true)
                 .sameSite("None")

--- a/back/ministory/src/main/java/seongmin/ministory/api/user/service/UserService.java
+++ b/back/ministory/src/main/java/seongmin/ministory/api/user/service/UserService.java
@@ -81,7 +81,6 @@ public class UserService {
         body.add("redirect_uri", githubRedirectUri);
 
         HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(body, httpHeaders);
-//        log.info("Before Get AccessToken");
 
         ResponseEntity<Map> responseEntity = restTemplate.exchange(
                 tokenUrl,
@@ -89,12 +88,11 @@ public class UserService {
                 requestEntity,
                 Map.class
         );
-        log.info("Get Access responseEntity: {}", responseEntity);
 
         Map<String, String> response = responseEntity.getBody();
 
         String accessToken = response.get("access_token");
-        log.info("AccessToken: {}", accessToken);
+
         return accessToken;
     }
 
@@ -138,25 +136,21 @@ public class UserService {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(body, httpHeaders);
 
-        log.info("Before Login");
         ResponseEntity<Map> responseEntity = restTemplate.exchange(
                 apiUrl,
                 HttpMethod.GET,
                 requestEntity,
                 Map.class
         );
-        log.info("Login responseEntity: {}", responseEntity);
 
         Map<String, ?> response = responseEntity.getBody();
         String githubId = response.get("id").toString();
 
-        log.info("Github Id: {}", githubId);
         User user = userRepository.findByOauthId(githubId).orElse(null); // orElse 구문에 setNewUser(response)을 넣었더니 왜 중복으로 계속 저장할까?
         if (user == null) { // 일단은 user == null 로 해결
             user = setGithubNewUser(response);
         }
 
-        log.info("User: {}", user.toString());
         return JwtTokenInfo.from(user);
     }
 

--- a/back/ministory/src/main/java/seongmin/ministory/api/user/service/UserService.java
+++ b/back/ministory/src/main/java/seongmin/ministory/api/user/service/UserService.java
@@ -128,6 +128,8 @@ public class UserService {
     public JwtTokenInfo loginWithGithub(String accessToken) {
         String apiUrl = "https://api.github.com/user";
 
+        log.warn("Here is login service");
+
         RestTemplate restTemplate = new RestTemplate();
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add("Accept", "application/json");

--- a/back/ministory/src/main/java/seongmin/ministory/api/user/service/UserService.java
+++ b/back/ministory/src/main/java/seongmin/ministory/api/user/service/UserService.java
@@ -128,8 +128,6 @@ public class UserService {
     public JwtTokenInfo loginWithGithub(String accessToken) {
         String apiUrl = "https://api.github.com/user";
 
-        log.warn("Here is login service");
-
         RestTemplate restTemplate = new RestTemplate();
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add("Accept", "application/json");

--- a/back/ministory/src/main/java/seongmin/ministory/common/auth/dto/CustomUserDetails.java
+++ b/back/ministory/src/main/java/seongmin/ministory/common/auth/dto/CustomUserDetails.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import seongmin.ministory.domain.user.entity.User;
 
 import java.util.Collection;
+import java.util.Collections;
 
 @Getter
 public class CustomUserDetails implements UserDetails {
@@ -47,7 +49,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        return Collections.singleton(new SimpleGrantedAuthority(role));
     }
 
     @Override

--- a/back/ministory/src/main/java/seongmin/ministory/common/config/JwtPropertyConfig.java
+++ b/back/ministory/src/main/java/seongmin/ministory/common/config/JwtPropertyConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import seongmin.ministory.common.jwt.JwtProperties;
 import seongmin.ministory.common.jwt.provider.AccessTokenProvider;
+import seongmin.ministory.common.jwt.provider.RefreshTokenProvider;
 
 @Configuration
 @EnableConfigurationProperties(JwtProperties.class)
@@ -15,6 +16,14 @@ public class JwtPropertyConfig {
         return new AccessTokenProvider (
                 jwtProperties.getSecret().getAccessSecretKey(),
                 jwtProperties.getToken().getAccessExpiration()
+        );
+    }
+
+    @Bean(name = "refreshTokenProvider")
+    public RefreshTokenProvider refreshTokenProvider(JwtProperties jwtProperties) {
+        return new RefreshTokenProvider (
+                jwtProperties.getSecret().getRefreshSecretKey(),
+                jwtProperties.getToken().getRefreshExpiration()
         );
     }
 }

--- a/back/ministory/src/main/java/seongmin/ministory/common/config/RedisConfig.java
+++ b/back/ministory/src/main/java/seongmin/ministory/common/config/RedisConfig.java
@@ -1,0 +1,21 @@
+package seongmin.ministory.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@RequiredArgsConstructor
+@EnableRedisRepositories
+@Configuration
+public class RedisConfig {
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+}

--- a/back/ministory/src/main/java/seongmin/ministory/common/jwt/ForbiddenToken/dto/ForbiddenToken.java
+++ b/back/ministory/src/main/java/seongmin/ministory/common/jwt/ForbiddenToken/dto/ForbiddenToken.java
@@ -1,0 +1,27 @@
+package seongmin.ministory.common.jwt.ForbiddenToken.dto;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Builder
+@Getter
+@RedisHash(value = "forbiddenToken")
+public class ForbiddenToken {
+    @Id
+    private final Long id;
+    @Indexed
+    private final String token;
+    @TimeToLive
+    private final Long ttl;
+
+    @Builder
+    public ForbiddenToken(Long id, String token, Long ttl) {
+        this.id = id;
+        this.token = token;
+        this.ttl = ttl;
+    }
+}

--- a/back/ministory/src/main/java/seongmin/ministory/common/jwt/ForbiddenToken/repository/ForbiddenTokenRepository.java
+++ b/back/ministory/src/main/java/seongmin/ministory/common/jwt/ForbiddenToken/repository/ForbiddenTokenRepository.java
@@ -1,0 +1,8 @@
+package seongmin.ministory.common.jwt.ForbiddenToken.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import seongmin.ministory.common.jwt.ForbiddenToken.dto.ForbiddenToken;
+
+public interface ForbiddenTokenRepository extends CrudRepository<ForbiddenToken, Long> {
+    boolean existsByToken(String refreshToken);
+}

--- a/back/ministory/src/main/java/seongmin/ministory/common/jwt/ForbiddenToken/service/ForbiddenTokenService.java
+++ b/back/ministory/src/main/java/seongmin/ministory/common/jwt/ForbiddenToken/service/ForbiddenTokenService.java
@@ -1,0 +1,30 @@
+package seongmin.ministory.common.jwt.ForbiddenToken.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import seongmin.ministory.common.jwt.ForbiddenToken.dto.ForbiddenToken;
+import seongmin.ministory.common.jwt.ForbiddenToken.repository.ForbiddenTokenRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ForbiddenTokenService {
+    private final ForbiddenTokenRepository forbiddenTokenRepository;
+
+    @Value("${jwt.token.refresh-expiration}")
+    private Long expiration;
+
+    public void save(String refreshToken) {
+        ForbiddenToken forbiddenToken = ForbiddenToken.builder()
+                .token(refreshToken)
+                .ttl(60L)
+                .build();
+        forbiddenTokenRepository.save(forbiddenToken);
+    }
+
+    public boolean isExist(String refreshToken) {
+        return forbiddenTokenRepository.existsByToken(refreshToken);
+    }
+}

--- a/back/ministory/src/main/java/seongmin/ministory/common/jwt/JwtProperties.java
+++ b/back/ministory/src/main/java/seongmin/ministory/common/jwt/JwtProperties.java
@@ -14,11 +14,13 @@ public class JwtProperties {
     @Data
     public static class Secret {
         private String accessSecretKey;
+        private String refreshSecretKey;
     }
 
     @Data
     public static class Token {
         private Duration accessExpiration;
         private String accessHeader;
+        private Duration refreshExpiration;
     }
 }

--- a/back/ministory/src/main/java/seongmin/ministory/common/jwt/provider/RefreshTokenProvider.java
+++ b/back/ministory/src/main/java/seongmin/ministory/common/jwt/provider/RefreshTokenProvider.java
@@ -2,7 +2,6 @@ package seongmin.ministory.common.jwt.provider;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import seongmin.ministory.common.jwt.dto.JwtTokenInfo;
 
@@ -13,13 +12,13 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-public class AccessTokenProvider implements TokenProvider {
+public class RefreshTokenProvider implements TokenProvider {
 
     private final SecretKey signature;
     private final Duration tokenExpiration;
 
-    public AccessTokenProvider(String accessSecret, Duration tokenExpiration) {
-        final byte[] secretKeyBytes = Base64.getDecoder().decode(accessSecret);
+    public RefreshTokenProvider(String refreshSecret, Duration tokenExpiration) {
+        final byte[] secretKeyBytes = Base64.getDecoder().decode(refreshSecret);
         this.signature = Keys.hmacShaKeyFor(secretKeyBytes);
         this.tokenExpiration = tokenExpiration;
     }
@@ -32,11 +31,12 @@ public class AccessTokenProvider implements TokenProvider {
                 .header()
                 .add(createHeader())
                 .and()
-                .claims(createClaims("MiniStory-access", tokenInfo))
+                .claims(createClaims("MiniStory-refresh", tokenInfo))
                 .expiration(createExpiration(now, tokenExpiration.toMillis()))
                 .issuedAt(now)
                 .signWith(signature)
                 .compact();
+
     }
 
     @Override
@@ -44,14 +44,14 @@ public class AccessTokenProvider implements TokenProvider {
         Map<String, Object> headers = new HashMap<>();
 
         headers.put("typ", "JWT");
-        headers.put("alg", "HS256"); // SignatureAlgorithm Deprecate 으로 인해 변경
+        headers.put("alg", "HS256");
         headers.put("regDate", System.currentTimeMillis());
 
         return headers;
     }
 
     @Override
-    public Date createExpiration(final Date now, long duration) {
+    public Date createExpiration(Date now, long duration) {
         return new Date(now.getTime() + duration);
     }
 
@@ -84,6 +84,4 @@ public class AccessTokenProvider implements TokenProvider {
     public Long getIdFromToken(String token) {
         return extractClaim(token).get("id", Long.class);
     }
-
-
 }

--- a/back/ministory/src/main/java/seongmin/ministory/common/response/code/AuthErrorCode.java
+++ b/back/ministory/src/main/java/seongmin/ministory/common/response/code/AuthErrorCode.java
@@ -14,6 +14,7 @@ public enum AuthErrorCode implements StatusCode {
      * 400 BAD_REQUEST
      */
     EMPTY_ACCESS_TOKEN(BAD_REQUEST, "액세스 토큰이 비어있습니다."),
+    EMPTY_REFRESH_TOKEN(BAD_REQUEST, "리프레시 토큰이 비어있습니다."),
     UNKNOWN_PROVIDER(BAD_REQUEST, "알 수 없는 프로바이더입니다."),
 
     /**
@@ -26,6 +27,7 @@ public enum AuthErrorCode implements StatusCode {
     WRONG_JWT_TOKEN(UNAUTHORIZED, "잘못된 토큰입니다(default)"),
     REFRESH_TOKEN_NOT_FOUND(UNAUTHORIZED, "없거나 삭제된 리프래시 토큰입니다."),
     UNSUPPORTED_JWT_TOKEN(UNAUTHORIZED, "지원하지 않는 토큰입니다"),
+    NEED_LOGIN(UNAUTHORIZED, "로그인이 필요합니다."),
 
     /**
      * 500 INTERNAL_SERVER_ERROR

--- a/back/ministory/src/main/java/seongmin/ministory/common/response/code/AuthErrorCode.java
+++ b/back/ministory/src/main/java/seongmin/ministory/common/response/code/AuthErrorCode.java
@@ -28,6 +28,7 @@ public enum AuthErrorCode implements StatusCode {
     REFRESH_TOKEN_NOT_FOUND(UNAUTHORIZED, "없거나 삭제된 리프래시 토큰입니다."),
     UNSUPPORTED_JWT_TOKEN(UNAUTHORIZED, "지원하지 않는 토큰입니다"),
     NEED_LOGIN(UNAUTHORIZED, "로그인이 필요합니다."),
+    INVALID_REFRESH_TOKEN(UNAUTHORIZED, "유효하지 않은 토큰입니다."),
 
     /**
      * 500 INTERNAL_SERVER_ERROR

--- a/back/ministory/src/main/resources/application.yml
+++ b/back/ministory/src/main/resources/application.yml
@@ -129,9 +129,11 @@ spring:
 jwt:
   secret:
     access-secret-key: ${JWT_ACCESS_SECRET}
+    refresh-secret-key: ${JWT_REFRESH_SECRET}
   token:
     access-expiration: 3600000 # 1시간(1000(ms) * 60(m) * 60(h))
     access-header: Authorization
+    refresh-expiration: 604800000 # 7일(1000(ms) * 60(m) * 60(h) * 24(h))
 
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8

--- a/back/ministory/src/main/resources/application.yml
+++ b/back/ministory/src/main/resources/application.yml
@@ -58,6 +58,7 @@ jwt:
   token:
     access-expiration: 3600000 # 1시간(1000(ms) * 60(m) * 60(h))
     access-header: Authorization
+    refresh-expiration: 86400000 # 1일(1000(ms) * 60(m) * 60(h) * 24(h))
 
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
@@ -139,7 +140,7 @@ jwt:
   token:
     access-expiration: 3600000 # 1시간(1000(ms) * 60(m) * 60(h))
     access-header: Authorization
-    refresh-expiration: 604800000 # 7일(1000(ms) * 60(m) * 60(h) * 24(h))
+    refresh-expiration: 86400000 # 1일(1000(ms) * 60(m) * 60(h) * 24(h))
 
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8

--- a/back/ministory/src/main/resources/application.yml
+++ b/back/ministory/src/main/resources/application.yml
@@ -51,6 +51,11 @@ spring:
         auto: false
   cors:
     allowed-origins: ${CORS_ORIGINS}
+  cache:
+    type: redis
+    redis:
+      host: localhost
+      port: 6379
 
 jwt:
   secret:
@@ -132,6 +137,11 @@ spring:
         auto: false
   cors:
     allowed-origins: ${CORS_ORIGINS}
+  cache:
+    type: redis
+    redis:
+      host: localhost
+      port: 6379
 
 jwt:
   secret:

--- a/back/ministory/src/main/resources/application.yml
+++ b/back/ministory/src/main/resources/application.yml
@@ -75,6 +75,12 @@ springdoc:
 spring.config.activate.on-profile: dev
 
 server:
+#  ssl:
+#    enabled: true
+#    key-store: keystore.p12
+#    key-store-password: SMzkdl139!
+#    key-store-type: PKCS12
+#    key-alias: bns-ssl
   port: 8080
 
 ssh:

--- a/front/app/Main.tsx
+++ b/front/app/Main.tsx
@@ -2,13 +2,13 @@
 
 import { useEffect, useState } from 'react'
 import { ContentItem } from '@/data/ContentItem'
-import projectsData from '@/data/projectsData'
 import RecentPostCard from '@/components/RecentPostCard'
 import process from 'process'
 
 async function fetchData(): Promise<{ data: { contents: ContentItem[] } }> {
   const data = await fetch(process.env.NEXT_PUBLIC_BACKEND_URL + '/api/v1/contents/recent', {
     method: 'GET',
+    credentials: 'include',
   })
   return data.json()
 }

--- a/front/app/blog/[id]/page.tsx
+++ b/front/app/blog/[id]/page.tsx
@@ -7,16 +7,16 @@ import Comments from '@/components/Comments'
 import CommentInput from '@/components/CommentInput'
 import process from 'process'
 import { AuthContext } from '@/components/hooks/useAuth'
+import { fetchWithoutCredentials } from '@/components/hooks/CustomFetch'
 
 const Layout = MyPost
 
 async function fetchContentData(id: number): Promise<{ data: ContentDetail }> {
-  const data = await fetch(process.env.NEXT_PUBLIC_BACKEND_URL + `/api/v1/contents/${id}`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json;charset=UTF-8',
-    },
-  })
+  const data = await fetchWithoutCredentials(
+    process.env.NEXT_PUBLIC_BACKEND_URL + `/api/v1/contents/${id}`,
+    'GET'
+  )
+
   return data.json()
 }
 

--- a/front/app/blog/delete/[id]/page.tsx
+++ b/front/app/blog/delete/[id]/page.tsx
@@ -4,21 +4,25 @@ import { useRouter } from 'next/navigation'
 import process from 'process'
 import { useContext, useEffect } from 'react'
 import { AuthContext } from '@/components/hooks/useAuth'
+import { fetchWithCredentials } from '@/components/hooks/CustomFetch'
 
 export default function DeleteContent(props) {
   const id = props.params.id
   const router = useRouter()
-  const { accessToken } = useContext(AuthContext)
+  const { accessToken, setAccessToken } = useContext(AuthContext)
 
   useEffect(() => {
     const deleteContent = async () => {
-      const response = await fetch(process.env.NEXT_PUBLIC_BACKEND_URL + `/api/v1/contents/${id}`, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
-          Authorization: 'Bearer ' + accessToken,
-        },
-      })
+      const response = await fetchWithCredentials(
+        process.env.NEXT_PUBLIC_BACKEND_URL + `/api/v1/contents/${id}`,
+        'DELETE',
+        accessToken
+      )
+
+      if (response.headers.has('Access-Token')) {
+        const newAccessToken = response.headers.get('Access-Token')
+        newAccessToken && setAccessToken(newAccessToken)
+      }
 
       if (response.ok) {
         alert('게시글이 삭제되었습니다')
@@ -30,7 +34,7 @@ export default function DeleteContent(props) {
     }
 
     deleteContent()
-  }, [id, accessToken, router])
+  }, [])
 
   return null
 }

--- a/front/app/blog/edit/[id]/page.tsx
+++ b/front/app/blog/edit/[id]/page.tsx
@@ -31,7 +31,7 @@ export default function EditContent(props) {
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
   const [selectedTags, setSelectedTags] = useState<string[]>([])
-  const { accessToken } = useContext(AuthContext)
+  const { accessToken, setAccessToken } = useContext(AuthContext)
   const { tags, fetchContentTag, fetchRegisterTag } = useContext(TagContext)
 
   useEffect(() => {
@@ -59,12 +59,22 @@ export default function EditContent(props) {
       content
     )
 
+    if (contentResponse.headers.has('Access-Token')) {
+      const newAccessToken = contentResponse.headers.get('Access-Token')
+      newAccessToken && setAccessToken(newAccessToken)
+    }
+
     const tagResponse = await fetchWithCredentials(
       process.env.NEXT_PUBLIC_BACKEND_URL + `/api/v1/contents/${id}/tags`,
       'POST',
       accessToken,
       { tags: selectedTags }
     )
+
+    if (tagResponse.headers.has('Access-Token')) {
+      const newAccessToken = tagResponse.headers.get('Access-Token')
+      newAccessToken && setAccessToken(newAccessToken)
+    }
 
     if (contentResponse.ok && tagResponse.ok) {
       alert('게시글 수정 성공!')

--- a/front/app/blog/post/[id]/page.tsx
+++ b/front/app/blog/post/[id]/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation'
 import { TagContext } from '@/components/hooks/useTag'
 import dynamic from 'next/dynamic'
 import process from 'process'
+import { fetchWithCredentials } from '@/components/hooks/CustomFetch'
 
 const MyEditorWithNoSSR = dynamic(() => import('@/components/MyEditor'), {
   ssr: false,
@@ -28,28 +29,18 @@ export default function NewPost(props) {
       complete: true,
     }
 
-    const contentResponse = await fetch(
+    const contentResponse = await fetchWithCredentials(
       process.env.NEXT_PUBLIC_BACKEND_URL + `/api/v1/contents/${id}`,
-      {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
-          Authorization: 'Bearer ' + accessToken,
-        },
-        body: JSON.stringify(content),
-      }
+      'PATCH',
+      accessToken,
+      content
     )
 
-    const tagResponse = await fetch(
+    const tagResponse = await fetchWithCredentials(
       process.env.NEXT_PUBLIC_BACKEND_URL + `/api/v1/contents/${id}/tags`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
-          Authorization: 'Bearer ' + accessToken,
-        },
-        body: JSON.stringify({ tags: selectedTags }),
-      }
+      'POST',
+      accessToken,
+      { tags: selectedTags }
     )
 
     if (contentResponse.ok && tagResponse.ok) {
@@ -70,28 +61,18 @@ export default function NewPost(props) {
       complete: false,
     }
 
-    const contentResponse = await fetch(
+    const contentResponse = await fetchWithCredentials(
       process.env.NEXT_PUBLIC_BACKEND_URL + `/api/v1/contents/${id}`,
-      {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
-          Authorization: 'Bearer ' + accessToken,
-        },
-        body: JSON.stringify(content),
-      }
+      'PATCH',
+      accessToken,
+      content
     )
 
-    const tagResponse = await fetch(
+    const tagResponse = await fetchWithCredentials(
       process.env.NEXT_PUBLIC_BACKEND_URL + `/api/v1/contents/${id}/tags`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
-          Authorization: 'Bearer ' + accessToken,
-        },
-        body: JSON.stringify({ tags: selectedTags }),
-      }
+      'POST',
+      accessToken,
+      { tags: selectedTags }
     )
 
     if (contentResponse.ok && tagResponse.ok) {

--- a/front/app/blog/post/[id]/page.tsx
+++ b/front/app/blog/post/[id]/page.tsx
@@ -19,7 +19,7 @@ export default function NewPost(props) {
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
   const [selectedTags, setSelectedTags] = useState<string[]>([])
-  const { accessToken } = useContext(AuthContext)
+  const { accessToken, setAccessToken } = useContext(AuthContext)
   const { tags, fetchContentTag, fetchRegisterTag } = useContext(TagContext)
 
   const handleComplete = async () => {
@@ -36,12 +36,22 @@ export default function NewPost(props) {
       content
     )
 
+    if (contentResponse.headers.has('Access-Token')) {
+      const newAccessToken = contentResponse.headers.get('Access-Token')
+      newAccessToken && setAccessToken(newAccessToken)
+    }
+
     const tagResponse = await fetchWithCredentials(
       process.env.NEXT_PUBLIC_BACKEND_URL + `/api/v1/contents/${id}/tags`,
       'POST',
       accessToken,
       { tags: selectedTags }
     )
+
+    if (tagResponse.headers.has('Access-Token')) {
+      const newAccessToken = tagResponse.headers.get('Access-Token')
+      newAccessToken && setAccessToken(newAccessToken)
+    }
 
     if (contentResponse.ok && tagResponse.ok) {
       alert('게시글 작성 성공!')

--- a/front/app/callback/github/page.tsx
+++ b/front/app/callback/github/page.tsx
@@ -18,6 +18,7 @@ const GithubCallback = () => {
         process.env.NEXT_PUBLIC_BACKEND_URL + '/api/v1/users/auth/github?code=' + authorizationCode,
         {
           method: 'GET',
+          credentials: 'include',
         }
       ).then((response) => {
         const accessToken = response.headers.get('Access-Token')
@@ -28,7 +29,7 @@ const GithubCallback = () => {
     }
 
     fetchData()
-  }, [getUserInfo, router])
+  }, [])
 
   return null
 }

--- a/front/app/callback/google/page.tsx
+++ b/front/app/callback/google/page.tsx
@@ -18,6 +18,7 @@ const GoogleCallback = () => {
         process.env.NEXT_PUBLIC_BACKEND_URL + '/api/v1/users/auth/google?code=' + authorizationCode,
         {
           method: 'GET',
+          credentials: 'include',
         }
       ).then((response) => {
         const accessToken = response.headers.get('Access-Token')
@@ -28,7 +29,7 @@ const GoogleCallback = () => {
     }
 
     fetchData()
-  }, [getUserInfo, router])
+  }, [])
 
   return null
 }

--- a/front/app/logout/page.tsx
+++ b/front/app/logout/page.tsx
@@ -9,16 +9,7 @@ export default function LogOut() {
   const { logout } = useContext(AuthContext)
 
   useEffect(() => {
-    const fetchLogout = async () => {
-      await fetch(process.env.NEXT_PUBLIC_BACKEND_URL + '/api/v1/users/logout', {
-        method: 'GET',
-        credentials: 'include',
-      }).then(() => {
-        logout()
-      })
-    }
-
-    fetchLogout()
+    logout()
     router.push('/')
   }, [])
   return null

--- a/front/app/logout/page.tsx
+++ b/front/app/logout/page.tsx
@@ -9,8 +9,17 @@ export default function LogOut() {
   const { logout } = useContext(AuthContext)
 
   useEffect(() => {
-    logout()
+    const fetchLogout = async () => {
+      await fetch(process.env.NEXT_PUBLIC_BACKEND_URL + '/api/v1/users/logout', {
+        method: 'GET',
+        credentials: 'include',
+      }).then(() => {
+        logout()
+      })
+    }
+
+    fetchLogout()
     router.push('/')
-  }, [logout, router])
+  }, [])
   return null
 }

--- a/front/components/CommentInput.tsx
+++ b/front/components/CommentInput.tsx
@@ -3,41 +3,26 @@
 import Box from '@mui/material/Box'
 import TextField from '@mui/material/TextField'
 import Button from '@mui/material/Button'
-import { useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import process from 'process'
+import { fetchWithCredentials } from '@/components/hooks/CustomFetch'
+import { AuthContext } from '@/components/hooks/useAuth'
 
 export default function CommentInput({ contentId, onCommentAdded }) {
-  const [accessToken, setAccessToken] = useState<string>()
+  const { accessToken } = useContext(AuthContext)
   const [comment, setComment] = useState('')
-
-  useEffect(() => {
-    const accessToken = localStorage.getItem('access-token')
-    if (accessToken != undefined) {
-      setAccessToken(accessToken)
-    }
-  }, [])
 
   const handleCommentSubmit = async () => {
     const data = {
       comment: comment,
     }
 
-    const requestOptions = {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(data),
-    }
-
-    if (accessToken) {
-      requestOptions.headers['Authorization'] = 'Bearer ' + accessToken
-    }
-
     try {
-      const response = await fetch(
+      const response = await fetchWithCredentials(
         process.env.NEXT_PUBLIC_BACKEND_URL + `/api/v1/contents/${contentId}/comments`,
-        requestOptions
+        'POST',
+        accessToken,
+        data
       )
 
       if (response.ok) {

--- a/front/components/CommentInput.tsx
+++ b/front/components/CommentInput.tsx
@@ -9,7 +9,7 @@ import { fetchWithCredentials } from '@/components/hooks/CustomFetch'
 import { AuthContext } from '@/components/hooks/useAuth'
 
 export default function CommentInput({ contentId, onCommentAdded }) {
-  const { accessToken } = useContext(AuthContext)
+  const { accessToken, setAccessToken } = useContext(AuthContext)
   const [comment, setComment] = useState('')
 
   const handleCommentSubmit = async () => {
@@ -24,6 +24,11 @@ export default function CommentInput({ contentId, onCommentAdded }) {
         accessToken,
         data
       )
+
+      if (response.headers.has('Access-Token')) {
+        const newAccessToken = response.headers.get('Access-Token')
+        newAccessToken && setAccessToken(newAccessToken)
+      }
 
       if (response.ok) {
         onCommentAdded()

--- a/front/components/Comments.tsx
+++ b/front/components/Comments.tsx
@@ -4,18 +4,14 @@ import { useEffect, useState } from 'react'
 import { CommentItem } from '@/data/CommentItem'
 import { Divider, List, ListItem, ListItemText } from '@mui/material'
 import process from 'process'
+import { fetchWithoutCredentials } from '@/components/hooks/CustomFetch'
 
 async function fetchComment(id: number): Promise<{ data: CommentItem[] }> {
-  const data = await fetch(
+  const response = await fetchWithoutCredentials(
     process.env.NEXT_PUBLIC_BACKEND_URL + `/api/v1/contents/${id}/comments`,
-    {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-    }
+    'GET'
   )
-  return data.json()
+  return response.json()
 }
 export default function Comments({ contentId, refreshComments }) {
   const [comments, setComments] = useState<CommentItem[]>([])

--- a/front/components/Header.tsx
+++ b/front/components/Header.tsx
@@ -46,7 +46,7 @@ const Header = () => {
               {link.title}
             </Link>
           ))}
-        {userInfo !== null && <WriteButton />}
+        {userInfo?.role === 'ROLE_ADMIN' && <WriteButton />}
         {userInfo === null ? <LoginButton /> : <LogoutButton />}
         <SearchButton />
         <ThemeSwitch />

--- a/front/components/WriteButton.tsx
+++ b/front/components/WriteButton.tsx
@@ -35,6 +35,7 @@ export default function WriteButton() {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        credentials: 'include',
       },
     }
 

--- a/front/components/WriteButton.tsx
+++ b/front/components/WriteButton.tsx
@@ -7,7 +7,7 @@ import { AuthContext } from '@/components/hooks/useAuth'
 import { fetchWithCredentials } from '@/components/hooks/CustomFetch'
 
 export default function WriteButton() {
-  const { accessToken } = useContext(AuthContext)
+  const { accessToken, setAccessToken } = useContext(AuthContext)
   const router = useRouter()
 
   const newPost = async () => {
@@ -17,6 +17,11 @@ export default function WriteButton() {
         'POST',
         accessToken
       )
+
+      if (response.headers.has('Access-Token')) {
+        const newAccessToken = response.headers.get('Access-Token')
+        newAccessToken && setAccessToken(newAccessToken)
+      }
 
       if (response.ok) {
         const { contentId } = await response.json().then((data) => data.data)

--- a/front/components/hooks/CustomFetch.tsx
+++ b/front/components/hooks/CustomFetch.tsx
@@ -1,0 +1,36 @@
+export async function fetchWithCredentials<T>(
+  url: string,
+  method: string,
+  accessToken: string,
+  body?: T
+): Promise<Response> {
+  const requestOptions: RequestInit = {
+    method: method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer ' + accessToken,
+      credentials: 'include',
+    },
+  }
+
+  if (body !== undefined) {
+    requestOptions.body = JSON.stringify(body)
+  }
+
+  return await fetch(url, requestOptions)
+}
+
+export async function fetchWithoutCredentials<T>(url: string, method: string, body?: T) {
+  const requestOptions: RequestInit = {
+    method: method,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  }
+
+  if (body !== undefined) {
+    requestOptions.body = JSON.stringify(body)
+  }
+
+  return await fetch(url, requestOptions)
+}

--- a/front/components/hooks/useAuth.tsx
+++ b/front/components/hooks/useAuth.tsx
@@ -29,6 +29,7 @@ export async function fetchUserInfo(accessToken: string): Promise<{ data: UserIn
   )
   return response.json()
 }
+
 const AuthProvider = ({ children }: Props) => {
   const [accessToken, setAccessToken] = useState<string>('')
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null)

--- a/front/components/hooks/useTag.tsx
+++ b/front/components/hooks/useTag.tsx
@@ -19,6 +19,7 @@ interface Props {
 export async function fetchRegisterTagData(): Promise<{ data: { tags: RegisterTag[] } }> {
   const data = await fetch(process.env.NEXT_PUBLIC_BACKEND_URL + '/api/v1/tags', {
     method: 'GET',
+    credentials: 'include',
   })
   return data.json()
 }
@@ -26,6 +27,7 @@ export async function fetchRegisterTagData(): Promise<{ data: { tags: RegisterTa
 export async function fetchTagData(): Promise<{ data: { tags: ContentTag[] } }> {
   const data = await fetch(process.env.NEXT_PUBLIC_BACKEND_URL + '/api/v1/tags/counts', {
     method: 'GET',
+    credentials: 'include',
   })
   return data.json()
 }

--- a/front/data/siteMetadata.js
+++ b/front/data/siteMetadata.js
@@ -44,7 +44,7 @@ const siteMetadata = {
   },
   newsletter: {
     // supports mailchimp, buttondown, convertkit, klaviyo, revue, emailoctopus
-    // Please add your .env file and modify it according to your selection
+    // Please add your .env.production file and modify it according to your selection
     provider: 'buttondown',
   },
   comments: {

--- a/front/layouts/ListLayoutWithTags.tsx
+++ b/front/layouts/ListLayoutWithTags.tsx
@@ -11,6 +11,7 @@ import { ContentItem } from '@/data/ContentItem'
 import { useContext, useEffect, useState } from 'react'
 import { TagContext } from '@/components/hooks/useTag'
 import process from 'process'
+import { fetchWithoutCredentials } from '@/components/hooks/CustomFetch'
 
 interface PaginationProps {
   totalPages: number
@@ -63,13 +64,12 @@ function Pagination({ totalPages, currentPage }: PaginationProps) {
 export async function fetchContentsData(
   pageNumber: number
 ): Promise<{ data: { contents: ContentItem[]; totalPage: number } }> {
-  const data = await fetch(
+  const response = await fetchWithoutCredentials(
     process.env.NEXT_PUBLIC_BACKEND_URL + `/api/v1/contents?page=${pageNumber}`,
-    {
-      method: 'GET',
-    }
+    'GET'
   )
-  return data.json()
+
+  return response.json()
 }
 
 export default function ListLayoutWithTags({ title }: ListLayoutProps) {

--- a/front/layouts/TagListLayout.tsx
+++ b/front/layouts/TagListLayout.tsx
@@ -65,13 +65,13 @@ async function fetchTagContentsData(
   pageNumber: number,
   tagName: string
 ): Promise<{ data: { contents: ContentItem[]; totalPage: number } }> {
-  const data = await fetch(
+  const response = await fetch(
     process.env.NEXT_PUBLIC_BACKEND_URL + `/api/v1/contents/tags/${tagName}?page=${pageNumber}`,
     {
       method: 'GET',
     }
   )
-  return data.json()
+  return response.json()
 }
 
 export default function ListLayoutWithTags({ title, tagName }: ListLayoutProps) {


### PR DESCRIPTION
#4 

### 변경 사항

1. 쿠키 사용을 위한 프론트엔드 fetch 구문 변경

withCredentials 옵션 사용을 위해, 모든 fetch 구문 일괄 적용할 수 있도록 2가지의 custom fetch 생성
<img width="944" alt="스크린샷 2024-06-03 오후 3 43 57" src="https://github.com/dnjsals45/ministory/assets/44596433/398eb3a3-8965-44c4-b06f-b934e21b4b00">

<img width="945" alt="스크린샷 2024-06-03 오후 3 44 22" src="https://github.com/dnjsals45/ministory/assets/44596433/b1b50213-1c87-48e9-9945-80dde2fb21e7">


2. RT 도입을 통한 jwt 토큰 유효성 검사 로직 강화(JWT 필터)
- 기존에는 AT만을 이용해서, AT가 필요한 url 과 필요하지 않은 url을 통해 구분하였음.
- RT 도입 이후에는 AT유효여부 및 RT유효 여부에 따른 시나리오를 구성하여 검사 강화 및 자동로그인 기능을 구현하였음
<img width="884" alt="스크린샷 2024-06-03 오후 3 46 59" src="https://github.com/dnjsals45/ministory/assets/44596433/2268c42d-7286-44f5-b28c-ac72138112ac">

- AT 유효 -> 통과
- AT 만료, RT 유효 -> 새로운 AT 생성 및 응답에 헤더로 같이 내려주게 됨
- AT 만료, RT 만료 -> 재 로그인 필요

3. 만료된 RT를 redis에 저장하여, 탈취된 토큰인지 확인할 수 있도록 함
- ForbiddenToken 의 유효기간은 RT의 만료기간과 동일하게 설정하여 일정 기간(RT 유효기간)이 지난 이후 redis에서 자동으로 삭제되게 하였음
- RT가 1분이 남더라도, FT의 경우에는 RT의 최대 만료기간과 동일하게 설정됨 (문제가 될 가능성이 없다고 생각하여 진행)

4. @PreAuthorize 구문 변경
- 기존에는 CustomUserDetails에 authorities을 필요하지 않다고 생각하여 등록하지 않았음
- 하지만 제공하는 기능을 이용하며 추후 모를 상황을 대비하기 위해 authorities 등록 후, Spring Security에서 제공하는 hasRole() 구문으로 변경하였음