### PR TITLE
조회수 중복 방지 기능 추가

### DIFF
--- a/back/ministory/src/main/java/seongmin/ministory/api/content/controller/ContentController.java
+++ b/back/ministory/src/main/java/seongmin/ministory/api/content/controller/ContentController.java
@@ -3,6 +3,7 @@ package seongmin.ministory.api.content.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,8 +52,9 @@ public class ContentController {
     @GetMapping("/{content_id}")
     @PreAuthorize("permitAll()")
     public ResponseEntity<?> getContent(@Parameter(name = "content_id", description = "게시글 번호")
-                                        @PathVariable(name = "content_id") Long contentId) {
-        return ResponseEntity.ok().body(SuccessResponse.from(contentService.getContent(contentId)));
+                                        @PathVariable(name = "content_id") Long contentId,
+                                        HttpServletRequest request) {
+        return ResponseEntity.ok().body(SuccessResponse.from(contentService.getContent(contentId, (String) request.getAttribute("viewerId"))));
     }
 
     @Operation(summary = "게시글 1개 생성", description = "기본적인 내용만 있는 게시글 생성")

--- a/back/ministory/src/main/java/seongmin/ministory/common/config/RedisConfig.java
+++ b/back/ministory/src/main/java/seongmin/ministory/common/config/RedisConfig.java
@@ -6,10 +6,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyValueAdapter;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
 @RequiredArgsConstructor
-@EnableRedisRepositories
+@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
 @Configuration
 public class RedisConfig {
     private final RedisProperties redisProperties;

--- a/back/ministory/src/main/java/seongmin/ministory/common/jwt/ForbiddenToken/service/ForbiddenTokenService.java
+++ b/back/ministory/src/main/java/seongmin/ministory/common/jwt/ForbiddenToken/service/ForbiddenTokenService.java
@@ -19,7 +19,7 @@ public class ForbiddenTokenService {
     public void save(String refreshToken) {
         ForbiddenToken forbiddenToken = ForbiddenToken.builder()
                 .token(refreshToken)
-                .ttl(60L)
+                .ttl(expiration / 1000)
                 .build();
         forbiddenTokenRepository.save(forbiddenToken);
     }

--- a/back/ministory/src/main/java/seongmin/ministory/common/viewerTrack/dto/ViewerTrack.java
+++ b/back/ministory/src/main/java/seongmin/ministory/common/viewerTrack/dto/ViewerTrack.java
@@ -1,0 +1,30 @@
+package seongmin.ministory.common.viewerTrack.dto;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Builder
+@Getter
+@RedisHash(value = "viewerTrack")
+public class ViewerTrack {
+    @Id
+    private final Long id;
+    @Indexed
+    private final String viewerId;
+    @Indexed
+    private final Long contentId;
+    @TimeToLive
+    private final Long ttl;
+
+    @Builder
+    public ViewerTrack(Long id, String viewerId, Long contentId, Long ttl) {
+        this.id = id;
+        this.viewerId = viewerId;
+        this.contentId = contentId;
+        this.ttl = ttl;
+    }
+}

--- a/back/ministory/src/main/java/seongmin/ministory/common/viewerTrack/repository/ViewerTrackRepository.java
+++ b/back/ministory/src/main/java/seongmin/ministory/common/viewerTrack/repository/ViewerTrackRepository.java
@@ -1,0 +1,8 @@
+package seongmin.ministory.common.viewerTrack.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import seongmin.ministory.common.viewerTrack.dto.ViewerTrack;
+
+public interface ViewerTrackRepository extends CrudRepository<ViewerTrack, Long> {
+    boolean existsByViewerIdAndContentId(String viewerId, Long contentId);
+}

--- a/back/ministory/src/main/java/seongmin/ministory/common/viewerTrack/service/ViewerTrackService.java
+++ b/back/ministory/src/main/java/seongmin/ministory/common/viewerTrack/service/ViewerTrackService.java
@@ -1,0 +1,35 @@
+package seongmin.ministory.common.viewerTrack.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import seongmin.ministory.common.viewerTrack.dto.ViewerTrack;
+import seongmin.ministory.common.viewerTrack.repository.ViewerTrackRepository;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+
+@Service
+@RequiredArgsConstructor
+public class ViewerTrackService {
+    private final ViewerTrackRepository viewerTrackRepository;
+
+    public void save(String viewerId, Long contentId) {
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        LocalDateTime tomorrow = now.plusDays(1).truncatedTo(ChronoUnit.DAYS);
+        long ttl = ChronoUnit.SECONDS.between(now, tomorrow);
+
+        ViewerTrack newTrack = ViewerTrack
+                .builder()
+                .viewerId(viewerId)
+                .contentId(contentId)
+                .ttl(ttl)
+                .build();
+
+        viewerTrackRepository.save(newTrack);
+    }
+
+    public boolean isExist(String viewerId, Long contentId) {
+        return viewerTrackRepository.existsByViewerIdAndContentId(viewerId, contentId);
+    }
+}

--- a/back/ministory/src/main/resources/application.yml
+++ b/back/ministory/src/main/resources/application.yml
@@ -129,7 +129,7 @@ spring:
     allowed-origins: ${CORS_ORIGINS}
   data:
     redis:
-      host: redis
+      host: localhost
       port: 6379
 
 jwt:

--- a/front/components/hooks/CustomFetch.tsx
+++ b/front/components/hooks/CustomFetch.tsx
@@ -9,8 +9,8 @@ export async function fetchWithCredentials<T>(
     headers: {
       'Content-Type': 'application/json',
       Authorization: 'Bearer ' + accessToken,
-      credentials: 'include',
     },
+    credentials: 'include',
   }
 
   if (body !== undefined) {
@@ -26,6 +26,7 @@ export async function fetchWithoutCredentials<T>(url: string, method: string, bo
     headers: {
       'Content-Type': 'application/json',
     },
+    credentials: 'include',
   }
 
   if (body !== undefined) {


### PR DESCRIPTION
### 추가 기능
- 조회수 중복 방지 기능 추가

조사 결과 세션, 쿠키 등 여러 가지 방법이 존재하지만 모두 장단점이 있다고 판단하였으며, 최종적으로 결정한 방법

쿠키(고유 ID부여) + redis 사용 으로 진행하였습니다.

이유는 다음과 같습니다.

> 기존의 JWT 필터에서, 로그인하지 않은 요청의 경우 Authentication 객체를 설정하지 않고 다음 필터로 이동
-> 게시글 조회의 경우 로그인 하지 않더라도 가능한데, 이를 판별할 수 있는 방법이 존재하지 않음
-> 브라우저 쿠키 값으로 UUID을 통해 고유 아이디를 부여하고 이를 JWT 필터 최상단에서 받음.
-> request.setAttribute 구문을 통하여 viewerId 설정
-> 게시글 조회 시 authentication 객체가 아닌, 고유 ID 값과 contentId 값을 매칭하여 한 번 접속하면 자정이 되기 전까지 redis에 저장
-> 자정이 된 경우 삭제
-> 모든 경우를 고유 ID라는 단순 쿠키값으로 처리하기에는 기존 보안 + 역할부여의 의미가 사라지기 떄문에 두 개를 동시에 사용하는 방식 선택
<img width="916" alt="스크린샷 2024-06-17 오후 8 56 00" src="https://github.com/dnjsals45/ministory/assets/44596433/7b42bfbc-84a0-46bf-afb2-07a1ca01347f">


또한, Spring Data Redis을 사용하며 @Indexed로 검색이 가능하게 설정한 값의 경우 TTL 여부와 관계없이 지워지지 않게 되는 현상을 발견하고, 이를 해결하기 위해 RedisConfig의 설정을 일부 변경하였습니다.
@EnableRedisRepositories에 추가로
@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP) 옵션 설정